### PR TITLE
Fix incorrect socket.io application in autohost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autohost",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Resource-driven http server",
   "main": "src/autohost.js",
   "author": "Alex Robson",

--- a/src/socketio.js
+++ b/src/socketio.js
@@ -68,7 +68,7 @@ module.exports = function( Host ) {
 				}
 
 				socket.publish = function( topic, message ) {
-					socket.emit( topic, message );
+					socket.json.send( { topic: topic, body: message } );
 				};
 
 				socket.on( 'client.identity', function( data ) {


### PR DESCRIPTION
Sending message in autohost via socket.io now uses .send. The payload sent is { topic: '', body: {} }. This will allow much more robust socket message handling via a library like postal vs having to define an event handler for every possible message sent from the server.
