### PR TITLE
Support resetting of internal userCountCheck for use in specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.3.0
 Primary motivation here is to begin work on a version of autohost that will work well with a hypermedia library ( [hyped](https://github.com/leankit-labs/hyped) ). This is a breaking change because of several structural and naming changes to how resources get modeled.
 
+### prerelease 19
+Allow for specs to reset userCountCheck so that the auth providers can be reset after adding or removing accounts and get expected behavior.
+
 ### prerelease 18
  * Rewrite specifications
  * Provide test harness

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autohost",
-  "version": "0.3.0-18",
+  "version": "0.3.0-19",
   "description": "Resource driven, transport agnostic host",
   "main": "src/index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ function setup( authProvider ) {
 
 	httpAdapter = httpAdapterFn( config, authProvider, wrapper.http, request, metrics );
 	api.addAdapter( httpAdapter );
+	wrapper.passport = httpAdapter.passport;
 
 	// API metadata
 	if ( !config.noOptions ) {


### PR DESCRIPTION
This is really a change being put in to support integration tests in auth libraries.