### PR TITLE
Bug-fix: Connect-redis doesn't get express-session instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.3.0
 Primary motivation here is to begin work on a version of autohost that will work well with a hypermedia library ( [hyped](https://github.com/leankit-labs/hyped) ). This is a breaking change because of several structural and naming changes to how resources get modeled.
 
+### prerelease 21
+Bug fix - correct problem with how express-session was exposed causing connect-redis to fail on init.
+
 ### prerelease 20
  * Add unique identifiers to socket connections
  * Update assertions to chai

--- a/demo/index.js
+++ b/demo/index.js
@@ -8,7 +8,7 @@ var authProvider = require( 'autohost-nedb-auth' )( {} );
 // 	} );
 var hyped = require( 'hyped' )();
 // var redis = require( 'redis' ).createClient(); // assumes a locally running redis server
-// var RedisStore = require( 'connect-redis' )( host.session );
+// var RedisStore = require( 'connect-redis' )( host );
 // var store = new RedisStore( {
 // 		client: redis,
 // 		prefix: 'ah:'
@@ -16,20 +16,22 @@ var hyped = require( 'hyped' )();
 
 try {
 	host.init( {
-				port: 4041,
-				resources: './demo/resource',
-				static: './demo/public',
-				socketIO: true,
-				websockets: true,
-				origin: 'console',
-				anonymous: [ '/$', '/js', '/css' ],
-				sessionId: 'myapp.sid',
-				sessionSecret: 'youdontevenknow',
-				noOptions: true,
-				urlStrategy: hyped.urlStrategy
-				// sessionStore: store,
-			}, authProvider )
+		port: 4041,
+		resources: './demo/resource',
+		static: './demo/public',
+		socketIO: true,
+		websockets: true,
+		origin: 'console',
+		anonymous: [ '/$', '/js', '/css' ],
+		sessionId: 'myapp.sid',
+		sessionSecret: 'youdontevenknow',
+		noOptions: true,
+		urlStrategy: hyped.urlStrategy
+		// sessionStore: store,
+	}, authProvider )
 		.then( hyped.addResources );
 
 	hyped.setupMiddleware( host );
-} catch( e ) { console.log( e.stack ); }
+} catch ( e ) {
+	console.log( e.stack );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autohost",
-  "version": "0.3.0-20",
+  "version": "0.3.0-21",
   "description": "Resource driven, transport agnostic host",
   "main": "src/index.js",
   "dependencies": {

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -6,7 +6,8 @@ var wrapper = {
 	attach: applyMiddelware,
 	configure: configure,
 	useCookies: applyCookieMiddleware,
-	useSession: applySessionMiddleware
+	useSession: applySessionMiddleware,
+	sessionLib: sessionLib
 };
 var config, metrics, session, cookieParser;
 
@@ -85,5 +86,3 @@ module.exports = function( meter ) {
 	cookieParser = cookies();
 	return wrapper;
 };
-
-module.exports.sessionLib = sessionLib;

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ var wrapper = {
 	meta: undefined,
 	http: httpFn( request, middleware, metrics ),
 	socket: undefined,
-	session: middlewareLib.sessionLib,
+	session: middleware.sessionLib,
 	on: onEvent
 };
 


### PR DESCRIPTION
Bug fix - correct an issue with how express-session was exposed causing connect-redis to fail on init