### PR TITLE
Bug fix - external fount instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.3.0
 Primary motivation here is to begin work on a version of autohost that will work well with a hypermedia library ( [hyped](https://github.com/leankit-labs/hyped) ). This is a breaking change because of several structural and naming changes to how resources get modeled.
 
+### prerelease 22
+Bug fix - autohost accidentally pegged fount version and bad initialization order caused custom fount instances to get ignored.
+
 ### prerelease 21
 Bug fix - correct problem with how express-session was exposed causing connect-redis to fail on init.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autohost",
-  "version": "0.3.0-21",
+  "version": "0.3.0-22",
   "description": "Resource driven, transport agnostic host",
   "main": "src/index.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "debug": "^1.0.4",
     "express": "^4.7.2",
     "express-session": "^1.7.2",
-    "fount": "0.0.4",
+    "fount": "~0.0.6",
     "gulp-esformatter": "^1.0.1",
     "lodash": "^2.4.1",
     "multer": "^0.1.3",

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,8 @@ var wrapper = {
 };
 
 function initialize( cfg, authProvider, fount ) {
-	api = require( './api.js' )( wrapper, cfg );
 	wrapper.fount = fount || internalFount;
+	api = require( './api.js' )( wrapper, cfg );
 	if ( initialized ) {
 		api.startAdapters();
 		return when( api.resources );


### PR DESCRIPTION
Bug fix - external fount instance didn't replace AH's default instance