### PR TITLE
Bug fix & Metronic version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 0.3.0
 Primary motivation here is to begin work on a version of autohost that will work well with a hypermedia library ( [hyped](https://github.com/leankit-labs/hyped) ). This is a breaking change because of several structural and naming changes to how resources get modeled.
 
+### Current
+ * Update metronic version to 0.2.0
+ * Bug fix - resolving external resource modules should correctly differentiate between relative paths and NPM modules
+
 ### 0.3.0
  * Use metronic for metrics
  * Use whistlepunk for logging

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ autohost would not exist without the following libraries:
  * express-session 	1.7.2
  * fount 			0.0.6
  * lodash 			2.4.1
- * metronic 		0.1.6
+ * metronic 		0.2.0
  * multer 			0.1.3
  * passport 		0.2.0
  * postal 			1.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autohost",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Resource driven, transport agnostic host",
   "main": "src/index.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "express-session": "^1.7.2",
     "fount": "~0.0.6",
     "lodash": "^2.4.1",
-    "metronic": "~0.1.6",
+    "metronic": "~0.2.0",
     "multer": "^0.1.3",
     "node-uuid": "^1.4.1",
     "parseurl": "^1.2.0",

--- a/src/api.js
+++ b/src/api.js
@@ -92,7 +92,12 @@ function loadAll( resourcePath ) {
 	var loadActions = [ loadResources( resourcePath ) ] || [];
 	if ( config.modules ) {
 		_.each( config.modules, function( mod ) {
-			var modPath = require.resolve( path.resolve( process.cwd(), mod ) );
+			var modPath;
+			if ( /[\/]/.test( mod ) ) {
+				modPath = require.resolve( path.resolve( process.cwd(), mod ) );
+			} else {
+				modPath = require.resolve( mod );
+			}
 			loadActions.push( loadModule( modPath ) );
 		} );
 	}


### PR DESCRIPTION
* Bug fix - only use path resolve for external modules if the name contains path characters. 
* Update metronic to version 0.2.0.