### PR TITLE
User optimizations

### DIFF
--- a/src/harness.js
+++ b/src/harness.js
@@ -1,3 +1,4 @@
+var _ = require( 'lodash' );
 var path = require( 'path' );
 var port = 8988;
 var defaults = {

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -91,7 +91,7 @@ function requestMetrics( state, req, res, next ) {
 	var timer = state.metrics.timer( [ urlKey, 'http', 'duration' ] );
 
 	res.once( 'finish', function() {
-		var user = req.authenticatedUser;
+		var user = _.isObject( req.user ) ? ( req.user.name || req.user.username || req.user.id ) : 'anonymous';
 		var method = req.method.toUpperCase();
 		var read = req.connection.bytesRead;
 		var readKB = read / 1024;

--- a/src/http/passport.js
+++ b/src/http/passport.js
@@ -38,7 +38,6 @@ function getAuthMiddleware( state, uri ) {
 
 function getRoles( state, req, res, next ) {
 	var userName = _.isObject( req.user ) ? req.user.name : undefined;
-	req.authenticatedUser = userName || req.user.id || 'anonymous';
 
 	function onError( err ) {
 		state.metrics.authorizationErrors.record();
@@ -95,7 +94,7 @@ function getSocketRoles( state, user ) {
 }
 
 function getUserString( user ) {
-	return user.name ? user.name : JSON.stringify( user );
+	return user.name || user.username || user.id || JSON.stringify( user );
 }
 
 function resetUserCount( state ) {


### PR DESCRIPTION
This PR fixes a few things. First off was `authenticatedUser`. It was only used for logging, but `getRoles` isn't guaranteed to be called on each request, especially when using a Redis sessionStore. The result was log messages for `anonymous` even when the user was authenticated.

The second issue was the `JSON.stringify` which was producing incredibly long log statements when it failed on the `user.name` test. 

In both cases, I changed the test to be `user.name || user.username || user.id` before any fallback is used. In the case of logging, I moved the logic from `getRoles` to the logging statement.