### PR TITLE
Bind getRoles middleware handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "autohost-nedb-auth": "~0.2.0",
     "autohost-riak-auth": "~0.2.0",
-    "biggulp": "0.*.*",
+    "biggulp": "0.0.*",
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
     "connect-redis": "^2.1.0",

--- a/spec/integration/http.spec.js
+++ b/spec/integration/http.spec.js
@@ -213,7 +213,7 @@ describe( 'HTTP', function() {
 					headers: { 'Authorization': 'Bearer three' }
 				} )
 				.then( transformResponse( 'body', 'testHeader', 'setCookie' ), onError )
-				.should.eventually.have.property( 'body' ).that.equal( 'User lacks sufficient permissions' );
+				.should.eventually.have.property( 'body' ).that.equal( 'Could not determine user permission' );
 		} );
 	} );
 

--- a/src/http/passport.js
+++ b/src/http/passport.js
@@ -32,7 +32,7 @@ function getAuthMiddleware( state, uri ) {
 		} ) )
 		.concat( [ { path: uri, fn: whenNoUsers },
 			{ path: uri, fn: authConditionally.bind( undefined, state ), alias: 'conditionalAuth' },
-		{ path: uri, fn: getRoles, alias: 'userRoles' } ] );
+		{ path: uri, fn: getRoles.bind( undefined, state ), alias: 'userRoles' } ] );
 	return list;
 }
 


### PR DESCRIPTION
Found an issue today where the `getRoles` handler was acting as an error-handling middleware, because it needs to be passed with `state` bound as its first arg. Express uses the length of the function to determine if it is an error handler (err, req, res, next) vs. (req, res, next).

I also changed the biggulp dependency to `0.0.*` for now. When upgrading to `0.1.0` and using the default config, there are a number of jshint issues that would need to be resolved and I think that would be best for a separate PR.