### PR TITLE
Moved getUserString into a config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.4.x
 
+### Latest
+Enhancement - getUserString is now shared as an overrideable global config option
+
 ### 0.4.4
 Bug fix - getRoles was incorrectly being treated as error handling middleware
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The object literal follows the format:
 
 	session: 				// session configuration
 	cookie: 				// session cookie configuration
+	getUserString:			// method to return a string id for a user
 
 	logging: {}, 			// configuration passed to autohost's whistlepunk instance
 	fount: undefined, 		// pass the app's fount instance to autohost
@@ -166,6 +167,25 @@ Each library supports all optional features and can be managed from the [admin a
 
 Planned support for:
  * MS SQL server
+
+### getUserString
+
+ The `getUserString` option expects a method that accepts `user` as its only parameter, and returns a string (used for logging) to identify the user. The default method provided attempts the following steps:
+
+ * return `user.name` if available, otherwise:
+ * return `user.username` if available, otherwise:
+ * return `user.id` if available, otherwise:
+ * return `JSON.stringify( user )`
+
+ Override this method with custom logic if the default does not match your field names on your user object. For instance:
+
+ ```js
+ {
+ 	getUserString: function ( user ) {
+ 		return user.login;
+ 	}
+ }
+ ```
 
 ### fount
 [fount](https://github.com/LeanKit-Labs/fount) is a dependency injection library for Node. If the application is using fount, the application's instance can be provided at the end of the init call so that resources will have access to the same fount instance the application is using. The fount instance in use by `autohost` is available via `host.fount`.

--- a/spec/behavior/index.spec.js
+++ b/spec/behavior/index.spec.js
@@ -3,6 +3,7 @@ var fount = require( 'fount' );
 var request = require( 'request' );
 
 var middleware, http, httpAdapter, socket, socketAdapter, transport, log;
+var noop = function (){};
 function getHost() {
 	middleware = {
 		configure: function( config ) {
@@ -80,7 +81,7 @@ describe( 'Index', function() {
 	describe( 'with defaults', function() {
 		var host;
 		before( function() {
-			host = getHost()( { test: true } );
+			host = getHost()( { test: true, getUserString: noop } );
 		} );
 
 		it( 'should get internal fount reference', function() {
@@ -88,16 +89,16 @@ describe( 'Index', function() {
 		} );
 
 		it( 'should pass configuration to middleware library', function() {
-			middleware.args.should.eql( [ { test: true } ] );
+			middleware.args.should.eql( [ { test: true, getUserString: noop } ] );
 		} );
 
 		it( 'should pass state and configuration to transport library', function() {
-			transport.args.should.eql( [ host, { test: true } ] );
+			transport.args.should.eql( [ host, { test: true, getUserString: noop } ] );
 		} );
 
 		it( 'should initialize http adapter', function() {
 			httpAdapter.args.should.eql( [
-				{ test: true },
+				{ test: true, getUserString: noop },
 				undefined,
 				http,
 				request
@@ -105,12 +106,12 @@ describe( 'Index', function() {
 		} );
 
 		it( 'should initialize socket', function() {
-			socket.args.should.eql( [ { test: true }, http ] );
+			socket.args.should.eql( [ { test: true, getUserString: noop }, http ] );
 		} );
 
 		it( 'should initialize socket adapter', function() {
 			socketAdapter.args.should.eql( [
-				{ test: true },
+				{ test: true, getUserString: noop },
 				undefined,
 				host.socket
 			] );

--- a/src/http/adapter.js
+++ b/src/http/adapter.js
@@ -50,7 +50,7 @@ function buildPath( pathSpec ) {
 
 function checkPermissionFor( state, user, context, action ) {
 	log.debug( 'Checking %s\'s permissions for %s',
-		getUserString( user ), action
+		state.config.getUserString( user ), action
 	);
 	state.metrics.authorizationAttempts.record( 1, { name: 'HTTP_AUTHORIZATION_ATTEMPTS' } );
 	var timer = state.metrics.authorizationTimer();
@@ -99,10 +99,6 @@ function getActionMetadata( state, resource, actionName, action, meta, resources
 		resourceKey: resourceKey,
 		url: url
 	};
-}
-
-function getUserString( user ) {
-	return user.name ? user.name : JSON.stringify( user );
 }
 
 function hasPrefix( state, url ) {
@@ -190,12 +186,12 @@ function wireupAction( state, resource, actionName, action, metadata, resources 
 					if ( pass ) {
 						meta.authGranted();
 						log.debug( 'HTTP activation of action %s (%s %s) for %j granted',
-							meta.alias, action.method, meta.url, getUserString( req.user ) );
+							meta.alias, action.method, meta.url, state.config.getUserString( req.user ) );
 						respond( state, meta, req, res, resource, action );
 					} else {
 						meta.authRejected();
 						log.debug( 'User %s was denied HTTP activation of action %s (%s %s)',
-							getUserString( req.user ), meta.alias, action.method, meta.url );
+							state.config.getUserString( req.user ), meta.alias, action.method, meta.url );
 						if ( !res._headerSent ) {
 							res.status( 403 ).send( 'User lacks sufficient permissions' );
 						}

--- a/src/http/passport.js
+++ b/src/http/passport.js
@@ -43,7 +43,7 @@ function getRoles( state, req, res, next ) {
 		state.metrics.authorizationErrors.record( 1, { name: 'HTTP_AUTHORIZATION_ERRORS' } );
 		req.user.roles = [];
 		timer.record( { name: 'HTTP_AUTHORIZATION_DURATION' } );
-		log.debug( 'Failed to get roles for %s with %s', getUserString( req.user ), err.stack );
+		log.debug( 'Failed to get roles for %s with %s', state.config.getUserString( req.user ), err.stack );
 		// during a socket connection, express is not fully initialized and this call fails ... hard
 		try {
 			res.status( 500 ).send( 'Could not determine user permissions' );
@@ -74,12 +74,12 @@ function getSocketRoles( state, user ) {
 	function onError( err ) {
 		state.metrics.authorizationErrors.record( 1, { name: 'WS_AUTHORIZATION_ERRORS' } );
 		timer.record( { name: 'WS_AUTHORIZATION_DURATION' } );
-		log.debug( 'Failed to get roles for %s with %s', getUserString( user ), err.stack );
+		log.debug( 'Failed to get roles for %s with %s', state.config.getUserString( user ), err.stack );
 		return [];
 	}
 
 	function onRoles( roles ) {
-		log.debug( 'Got roles [ %s ] for %s', roles, getUserString( user ) );
+		log.debug( 'Got roles [ %s ] for %s', roles, state.config.getUserString( user ) );
 		timer.record( { name: 'WS_AUTHORIZATION_DURATION' } );
 		return roles;
 	}
@@ -91,10 +91,6 @@ function getSocketRoles( state, user ) {
 		return state.authProvider.getUserRoles( user, {} )
 			.then( onRoles, onError );
 	}
-}
-
-function getUserString( user ) {
-	return user.name || user.username || user.id || JSON.stringify( user );
 }
 
 function resetUserCount( state ) {
@@ -138,6 +134,7 @@ function withAuthLib( authProvider ) {
 
 module.exports = function( config, authProvider ) {
 	var state = {
+		config: config,
 		authProvider: authProvider,
 		metrics: metronic(),
 		passportInitialize: passport.initialize(),

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ var internalFount = require( 'fount' );
 
 function initialize( config, authProvider, fount ) {
 	config = config || {};
+	_.defaults( config, {
+		getUserString: function( user ) {
+			return user.name || user.username || user.id || JSON.stringify( user );
+		}
+	} );
 	authProvider = authProvider || config.authProvider;
 	require( './log' )( config.logging || {} );
 	var metrics = require( './metrics' )( config.metrics || {} );

--- a/src/mock/auth.js
+++ b/src/mock/auth.js
@@ -53,7 +53,7 @@ function checkPermission( user, action, context ) {
 }
 
 function getUserString( user ) {
-	return user.name ? user.name : JSON.stringify( user );
+	return user.name || user.username || user.id || JSON.stringify( user );
 }
 
 function hasPermissions( userRoles, actionRoles, context ) {

--- a/src/websocket/adapter.js
+++ b/src/websocket/adapter.js
@@ -11,7 +11,7 @@ function buildActionTopic( resourceName, action ) {
 }
 
 function checkPermissionFor( state, user, context, action ) {
-	log.debug( 'Checking %s\'s permissions for %s', getUserString( user ), action );
+	log.debug( 'Checking %s\'s permissions for %s', state.config.getUserString( user ), action );
 	return state.authProvider.checkPermission( user, action, context )
 		.then( null, function( err ) {
 			log.debug( 'Error during check permissions: %s', err.stack );
@@ -20,10 +20,6 @@ function checkPermissionFor( state, user, context, action ) {
 		.then( function( granted ) {
 			return granted;
 		} );
-}
-
-function getUserString( user ) {
-	return user.name ? user.name : JSON.stringify( user );
 }
 
 function start( state ) {
@@ -103,12 +99,12 @@ function wireupAction( state, resource, actionName, action, metadata ) {
 					if ( pass ) {
 						meta.authGranted();
 						log.debug( 'WS activation of action %s for %s granted',
-							meta.alias, getUserString( client.user ) );
+							meta.alias, state.config.getUserString( client.user ) );
 						respond( state, meta, resource, action, client, data, message, resourceTimer );
 					} else {
 						meta.authRejected();
 						log.debug( 'User %s was denied WS activation of action %s',
-							getUserString( client.user ), meta.alias );
+							state.config.getUserString( client.user ), meta.alias );
 						client.publish( data.replyTo || meta.topic,
 							'User lacks sufficient permissions' );
 					}


### PR DESCRIPTION
Updated auth mock to match default for getUserString

Even after pr #38, I was still seeing our entire user object stringified which makes for logs that are really hard to read in debug mode. So instead of just updating all the methods to match, I allow for a shared config version to be passed in. By default it matches the change in PR #38, but allows the consuming user to override this as needed.

I am happy to move stuff around or take a different approach if any of this seems ugly to you.