### PR TITLE
Query string no longer overrides url param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.4.x
 
+### Current
+ * A query string value can no longer override a URL parameter (Matches behavior of the `data` object)
+
 ### 0.4.7
  * Add authorize predicate to resource actions to support alternate authorization approach
 

--- a/spec/behavior/httpEnvelope.spec.js
+++ b/spec/behavior/httpEnvelope.spec.js
@@ -605,17 +605,17 @@ describe( 'HTTP Envelope', function() {
 				envelope = new ( envelopeFn( request ))( req, res, 'test' );
 			} );
 
-			it( 'should not override path variables with query parameters', function() {
+			it( 'should not override path variables with query parameters on data', function() {
 				envelope.data.should.eql( {
 					one: 1,
 					two: 2
 				} );
 			} );
 
-			it( 'should write query parameters to params on envelope', function() {
+			it( 'should not override path variables with query parameters on params', function() {
 				envelope.params.should.eql( {
-					one: 3,
-					two: 4
+					one: 1,
+					two: 2
 				} );
 			} );
 		} );
@@ -648,10 +648,10 @@ describe( 'HTTP Envelope', function() {
 				} );
 			} );
 
-			it( 'should write query parameters to params on envelope', function() {
+			it( 'should not override path variables with query parameters on params', function() {
 				envelope.params.should.eql( {
-					one: 3,
-					two: 4
+					one: 1,
+					two: 2
 				} );
 			} );
 		} );

--- a/spec/integration/http.spec.js
+++ b/spec/integration/http.spec.js
@@ -370,7 +370,7 @@ describe( 'HTTP', function() {
 				.should.eventually.deep.equal(
 				{
 					body: [
-						'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'an extension!',
+						'alpha', 'bravo', 'charlie', 'delta', 'charlie', 'foxtrot', 'an extension!',
 						{ one: 'alpha', two: 'bravo', three: 'charlie' }
 					],
 					header: 'look a header value!',
@@ -445,7 +445,7 @@ describe( 'HTTP', function() {
 				.should.eventually.deep.equal(
 				{
 					body: [
-						'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'an extension!',
+						'alpha', 'bravo', 'charlie', 'delta', 'charlie', 'foxtrot', 'an extension!',
 						{ one: 'alpha', two: 'bravo', three: 'charlie' }
 					],
 					header: 'look a header value!',
@@ -469,7 +469,7 @@ describe( 'HTTP', function() {
 				.should.eventually.deep.equal(
 				{
 					body: [
-						'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'an extension!',
+						'alpha', 'bravo', 'charlie', 'delta', 'charlie', 'foxtrot', 'an extension!',
 						{ one: 'alpha', two: 'bravo', three: 'charlie' }
 					],
 					header: 'look a header value!',

--- a/spec/integration/noauth.spec.js
+++ b/spec/integration/noauth.spec.js
@@ -133,7 +133,7 @@ describe( 'No Authentication', function() {
 					.should.eventually.deep.equal(
 					{
 						body: [
-							'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'an extension!',
+							'alpha', 'bravo', 'charlie', 'delta', 'charlie', 'foxtrot', 'an extension!',
 							{ one: 'alpha', two: 'bravo', three: 'charlie' }
 						],
 						header: 'look a header value!',

--- a/spec/integration/prefix.spec.js
+++ b/spec/integration/prefix.spec.js
@@ -102,7 +102,7 @@ describe( 'URL & API Prefix', function() {
 					.should.eventually.deep.equal(
 					{
 						body: [
-							'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'an extension!',
+							'alpha', 'bravo', 'charlie', 'delta', 'charlie', 'foxtrot', 'an extension!',
 							{ one: 'alpha', two: 'bravo', three: 'charlie' }
 						],
 						header: 'look a header value!',

--- a/src/http/httpEnvelope.js
+++ b/src/http/httpEnvelope.js
@@ -30,10 +30,12 @@ function HttpEnvelope( req, res, metricKey ) {
 	[ req.params, req.query ].forEach( function( source ) {
 		Object.keys( source ).forEach( function( key ) {
 			var val = source[ key ];
-			if ( this.data[ key ] === undefined || this.data[ key ] === null ) {
+			if ( !this.data.hasOwnProperty( key ) ) {
 				this.data[ key ] = val;
 			}
-			this.params[ key ] = val;
+			if ( !this.params.hasOwnProperty( key ) ) {
+				this.params[ key ] = val;
+			}
 		}.bind( this ) );
 	}.bind( this ) );
 


### PR DESCRIPTION
A query string value can no longer override a URL parameter (Matches behavior of the `data` object)