### PR TITLE
This PR addresses several middleware issues. Click Merge to see what happens next!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## 0.4.x
 
-### Current
+### Next
  * A query string value can no longer override a URL parameter (Matches behavior of the `data` object)
+ * Correct issue where insufficient parameters were passed to authorize predicates in hyped
+ * Default authorization (permission) checks to the end of all middleware
+ * Allow a placeholder to control when authorization checks occur in middleware stacks
+ * Return JSON `{ message: ... }` for all error responses
+ * Fix issue where express middleware that responds with an error code did not end HTTP stack evaluation
 
 ### 0.4.7
  * Add authorize predicate to resource actions to support alternate authorization approach

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Below are several examples of different middleware patterns. This should demonst
 // all middleware must return either the result of next or a promise/data structure
 middleware: [
 	function( envelope, next ) {
-		// invokes the next middelware or handle call
+		// invokes the next middleware or handle call
 		return next();
 	},
 	function( envelope, next ) {
@@ -374,7 +374,9 @@ __IMPORTANT__
 Middleware **must** return either the result of the `next` call _or_ a promise/data structure to short circuit the stack with a response. They are mutually exclusive. Do not call both. Do not fail to return one or the other.
 
 ### authorize
-An optional predicate for checking the users permission. The envelope is provided to the function and should return a boolean or a promise that resolves to a boolean indicating whether or not the user can perform the requested action.
+The `authorize` predicate was added to actions to allow for much more fine grained, explicit control of user authorization. By default, authorization checks are performed after _all_ middleware has run. This allows middleware to provide any necessary data on the envelope's context so that the authorization strategy can use this in determining the user's access level.
+
+To change this, provide the string "authorize" in place of a middleware call in the resource or action middleware property and the check will be performed where the string appeared in the stack. This allows an application to short-circuit the stack and avoid running middleware that performs expensive and unnecessary i/o if the user does not have permission to perform the action.
 
 > Note: when present, this _overrides_ rather than augments any authorization check that would have been performed by a configured autohost auth library.
 
@@ -584,7 +586,7 @@ These events can be subscribed to via `host.on`:
  * 'socket.client.identified', { socket: socketConnection, id: id } - raised when client reports unique id
  * 'socket.client.closed', { socket: socketConnection, id: id } - raised when client disconnects the websocket connection
 
-## Auth
+## Auth - via Auth Provider
 Authentication and authorization are supplied by an auth provider library that conforms to autohost's auth specifications. You can read more about that at [here](/blob/master/docs/authprovider.md).
 
 ### Programmatic control

--- a/src/http/http.js
+++ b/src/http/http.js
@@ -209,7 +209,7 @@ function registerRoute( state, url, method, callback ) {
 					callback( req, res );
 				} catch ( err ) {
 					log.debug( 'ERROR! route: %s %s failed with %s', method.toUpperCase(), url, err.stack );
-					res.status( 500 ).send( 'Server error at ' + method.toUpperCase() + ' ' + url );
+					res.status( 500 ).send( { message: 'Server error at ' + method.toUpperCase() + ' ' + url } );
 				}
 			} else {
 				callback( req, res );

--- a/src/http/passport.js
+++ b/src/http/passport.js
@@ -45,12 +45,17 @@ function getRoles( state, req, res, next ) {
 		timer.record( { name: 'HTTP_AUTHORIZATION_DURATION' } );
 		log.debug( 'Failed to get roles for %s with %s', state.config.getUserString( req.user ), err.stack );
 		// during a socket connection, express is not fully initialized and this call fails ... hard
-		try {
-			res.status( 500 ).send( 'Could not determine user permissions' );
-		} catch ( err ) {
-			log.warn( 'Could not reply with user permission error to request before express is fully initialized.' );
+		if( state.config.socketio && /socket.io/.test( req.url ) ) {
+			next();
+		} else if ( state.config.websocket && /websocket/.test( req.url ) ) {
+			next();
+		} else {
+			try {
+				res.status( 500 ).send( { message: 'Could not determine user permissions' } );
+			} catch ( err ) {
+				log.warn( 'Could not reply with user permission error to request before express is fully initialized.' );
+			}
 		}
-		next();
 	}
 
 	function onRoles( roles ) {


### PR DESCRIPTION
 * A query string value can no longer override a URL parameter (Matches behavior of the `data` object)
 * Correct issue where insufficient parameters were passed to authorize predicates in hyped
 * Default authorization (permission) checks to the end of all middleware
 * Allow a placeholder to control when authorization checks occur in middleware stacks
 * Return JSON `{ message: ... }` for all error responses
 * Fix issue where express middleware that responds with an error code did not end HTTP stack evaluation