### PR TITLE
More consistent auth and resource error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.5.x
 
+### Next
+ * Allow auth errors to bubble up to the default error handler (or custom error handlers)
+
 ### 0.5.4
  * Fixed an issue where resource modules that return a promise for a resource were not having their relative path set
 

--- a/spec/integration/http.spec.js
+++ b/spec/integration/http.spec.js
@@ -221,6 +221,7 @@ describe( 'HTTP', function() {
 				},
 				cantneverhaz: {
 					url: '/busted',
+					method: "GET",
 					authorize: function() {
 						throw new Error( 'This is why you can\'t have nice things ...' );
 					},
@@ -405,7 +406,7 @@ describe( 'HTTP', function() {
 				.then( transformResponse( 'body', 'statusCode' ), onError )
 				.should.eventually.deep.equal(
 				{
-					body: { message: 'Server error at ALL /api/actionAuth/busted' },
+					body: { message: 'Server error' },
 					statusCode: 500
 				} );
 		} );
@@ -483,7 +484,7 @@ describe( 'HTTP', function() {
 					body: { four: 'delta' },
 					headers: { 'Authorization': 'Bearer four' }
 				} )
-				.should.eventually.have.deep.property( '[0].body' ).to.eql( { message: 'Server error at /api/test/args/alpha/bravo/charlie?three=echo&four=foxtrot' } );
+				.should.eventually.have.deep.property( '[0].body' ).to.eql( { message: 'Server error' } );
 		} );
 	} );
 

--- a/src/http/adapter.js
+++ b/src/http/adapter.js
@@ -60,10 +60,7 @@ function checkPermissionFor( state, permissionCheck, meta, action, envelope, nex
 		log.error( 'Error during check permissions: %s', err.stack );
 		state.metrics.authorizationErrors.record( 1, { name: 'HTTP_AUTHORIZATION_ERRORS' });
 		timer.record( { name: 'HTTP_AUTHORIZATION_DURATION' } );
-		return {
-			status: 500,
-			data: { message: 'Server error at ' + envelope.path }
-		};
+		throw err;
 	}
 
 	function onPermission( granted ) {


### PR DESCRIPTION
 * Allow auth errors to bubble up to the default error handler (or custom error handlers)
 * Capture resource errors closer to the resource when `handleRouteErrors` is turned on.

@arobson This PR was trying to accomplish a few things. Before this PR, errors in authorization could not benefit from autohost's top level error response. By re-throwing the error after metrics and logging, we can provide a nicer response. The second issue was related, and I'm not thrilled with the workaround `_ahAction = true` but I was trying to allow the pipeline to continue for resources as well (to use the global error responses). Totally open to feedback on this, and am just sending the PR so you can provide feedback and we can discuss the issue better.