### PR TITLE
Prevent HTTP resource actions from recording two timing metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## 0.5.x
 
+### Next
+ * Minor tweak to prevent posting two timing metrics for resource actions called via HTTP
+
 ### 0.5.8
  * Add differentiated handle feature (to support adding versioned handlers in hyped)
 
 ### 0.5.7
 
-* Fixed issue with data objects having no hasOwnProperty function
+ * Fixed issue with data objects having no hasOwnProperty function 
 
 ### 0.5.6
  * Provide a means to customize socket.io configuration

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,0 +1,8 @@
+var path = require( "path" );
+var autohost = require( path.resolve( __dirname, "../src/index" ) );
+var host = autohost( {
+	resources: path.resolve( __dirname, "./resource" ),
+	static: path.resolve( __dirname, "./public" )
+} );
+
+host.start();

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE=html>
+<html>
+	<head>
+	</head>
+	<body>
+		<h3>Hello world!</h3>
+	</body>
+</html>

--- a/demo/resource/hello/resource.js
+++ b/demo/resource/hello/resource.js
@@ -1,0 +1,14 @@
+module.exports = function() {
+	return {
+		name: "hello",
+		actions: {
+			default: {
+				url: "/",
+				method: "GET",
+				handle: function() {
+					return "hello world";
+				}
+			}
+		}
+	};
+};

--- a/src/http/adapter.js
+++ b/src/http/adapter.js
@@ -295,10 +295,7 @@ function wireupAction( state, resource, actionName, action, metadata, resources 
 		req._metricKey = meta.metricKey;
 		req._resource = resource.name;
 		req._action = actionName;
-		var timer = meta.getTimer();
-		res.once( 'finish', function() {
-			timer.record( { name: 'HTTP_API_DURATION' } );
-		} );
+		req._timer = meta.getTimer();
 		action.handle = getHandler( action.handle );
 		respond( state, meta, req, res, resource, action );
 	} );

--- a/src/http/middleware.js
+++ b/src/http/middleware.js
@@ -107,8 +107,8 @@ function requestMetrics( state, req, res, next ) {
 		var sent = req.connection._bytesDispatched;
 		var sentKB = sent ? sent / 1024 : 0;
 		var url = req.url;
-		var elapsed = timer.record( { name: 'HTTP_REQUEST_DURATION' } );
-
+		var elapsed;
+		
 		var metricKey = req._metricKey;
 		if ( metricKey ) {
 			var resourceRequests = state.metrics.meter( 'requests', 'count', metricKey );
@@ -117,6 +117,7 @@ function requestMetrics( state, req, res, next ) {
 			resourceRequests.record( 1, { name: 'HTTP_API_REQUESTS' } );
 			resourceIngress.record( read, { name: 'HTTP_API_INGRESS' } );
 			resourceEgress.record( sent, { name: 'HTTP_API_EGRESS' } );
+			elapsed = req._timer.record( { name: 'HTTP_API_DURATION' } );
 		} else {
 			var httpRequests = state.metrics.meter( [ urlKey, 'requests' ] );
 			var httpIngress = state.metrics.meter( [ urlKey, 'ingress' ], 'bytes' );
@@ -124,6 +125,7 @@ function requestMetrics( state, req, res, next ) {
 			httpRequests.record( 1, { name: 'HTTP_REQUESTS' } );
 			httpIngress.record( read, { name: 'HTTP_INGRESS' } );
 			httpEgress.record( sent, { name: 'HTTP_EGRESS' } );
+			elapsed = timer.record( { name: 'HTTP_REQUEST_DURATION' } );
 		}
 
 		log.info( '%s@%s %s (%d ms) [%s] %s %s (%d bytes) %s %s (%d bytes)',


### PR DESCRIPTION
This is to help cut down on the number of metrics created in statsd style metric collectors and remove any confusion resulting from two sets of very similar metrics.