### PR TITLE
Handle data without hasOwnProperty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.5.x
 
+* Fixed issue with data objects having no hasOwnProperty function
+
 ### 0.5.6
  * Provide a means to customize socket.io configuration
  * Update dependencies

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "whistlepunk": "^0.3.2"
   },
   "devDependencies": {
-    "biggulp": "^0.2.2",
+    "biggulp": "^0.3.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "connect-redis": "^3.0.1",

--- a/spec/behavior/httpEnvelope.spec.js
+++ b/spec/behavior/httpEnvelope.spec.js
@@ -664,6 +664,37 @@ describe( 'HTTP Envelope', function() {
 				} );
 			} );
 		} );
+
+		describe( 'with body without hasOwnProperty', function() {
+			// The multer library, which is used for handling multipart form posts,
+			// sets the request body to Object.create( null ), which yields an object
+			// without the almost ubiquitous hasOwnProperty function.
+			// HttpEnvelope was using this function on the request body, which was
+			// blowing up on multipart forms. This example is just to recreate that case.
+			var envelope, req, res, request;
+			before( function() {
+				res = createResponse();
+				req = createRequest();
+				req.body = Object.create( null );
+				req.one = 'one';
+				req.two = 'two';
+				req.params = {
+					one: 1,
+					two: 2
+				};
+				req.query = {
+					one: 3,
+					two: 4
+				};
+				request = stubRequest();
+			} );
+
+			it( 'should not throw TypeError: undefined is not a function', function() {
+				expect( function() {
+					envelope = new ( envelopeFn( request ))( req, res, 'test' );
+				} ).to.not.throw( TypeError );
+			} );
+		} );
 	} );
 } );
 

--- a/src/http/httpEnvelope.js
+++ b/src/http/httpEnvelope.js
@@ -31,10 +31,10 @@ function HttpEnvelope( req, res, metricKey ) {
 	[ req.params, req.query ].forEach( function( source ) {
 		Object.keys( source ).forEach( function( key ) {
 			var val = source[ key ];
-			if ( !this.data.hasOwnProperty( key ) ) {
+			if ( !_.has( this.data, key ) ) {
 				this.data[ key ] = val;
 			}
-			if ( !this.params.hasOwnProperty( key ) ) {
+			if ( !_.has( this.params, key ) ) {
 				this.params[ key ] = val;
 			}
 		}.bind( this ) );
@@ -131,7 +131,7 @@ HttpEnvelope.prototype.renderError = function( host, resource, action, error ) {
 		actionError
 	);
 
-	if( strategy.status >= 500 ) {
+	if ( strategy.status >= 500 ) {
 		this.exceptions.record( 1, { name: 'HTTP_API_EXCEPTIONS' } );
 	} else {
 		this.errors.record( 1, { name: 'HTTP_API_ERRORS' } );


### PR DESCRIPTION
When sending multipart form data, sometimes the data object has no hasOwnProperty function, which was causing crashes. Just added a fallback for when that happens.