### PR TITLE
Regex fix for newer version of node

### DIFF
--- a/spec/behavior/regex.spec.js
+++ b/spec/behavior/regex.spec.js
@@ -140,11 +140,11 @@ describe( 'URL Regex', function() {
 	} );
 
 	describe( 'when pattern is already prefixed', function() {
-		var prefix = '/prefixed';
-		var url1 = '/prefixed/test/user/this/is/dumb';
+		var prefix = '/pre/fixed';
+		var url1 = '/pre/fixed/test/user/this/is/dumb';
 		var url2 = '/board/10/user';
-		var url3 = '/prefixed/user';
-		var match = /\/prefixed\/user[\/]?/;
+		var url3 = '/pre/fixed/user';
+		var match = /\/pre\/fixed\/user[\/]?/;
 		var url1Match, url2Match, url3Match;
 
 		before( function() {
@@ -153,7 +153,6 @@ describe( 'URL Regex', function() {
 			url2Match = pattern.test( url2 );
 			url3Match = pattern.test( url3 );
 		} );
-
 
 		it( 'it should match URLs beginning with the correct prefix', function() {
 			url3Match.should.be.true;

--- a/src/http/regex.js
+++ b/src/http/regex.js
@@ -9,7 +9,7 @@ function getRegex( pattern ) {
 
 function applyPrefix( prefix, pattern ) {
 	var original = parseRegex( pattern );
-	var prefixed = getRegex( '[^]?' + prefix.replace( '\/', '[\\\/]' ) );
+	var prefixed = getRegex( '\\^?' + prefix.replace( /\//g, '\\\\?/' ) );
 	if ( !prefix || prefixed.test( original ) ) {
 		return pattern;
 	} else {


### PR DESCRIPTION
Found an issue in newer versions of node when you have a child resource that uses a regex for the url. It seems related to changes with how escaped characters appear in the `toString` of a regex (https://bugs.chromium.org/p/v8/issues/detail?id=3229). The result was that in newer versions of Node, the final regex for a route was being prefixed multiple times.

This fix is backwards compatible and will work in old (v0.12.x) versions and new. Changes were made to the tests to demonstrate where this was breaking.