### PR TITLE
Fixes around socket connection bookkeeping

### DIFF
--- a/src/mock/auth.js
+++ b/src/mock/auth.js
@@ -24,7 +24,7 @@ function authenticate( req, res, next ) {
 }
 
 function authenticateCredentials( userName, password, done ) {
-	var user = _.where( wrapper.users, function( o, u ) {
+	var user = _.filter( wrapper.users, function( o, u ) {
 		return u === userName && o.password === password;
 	} );
 	log.debug( 'credentials %s:%s resulted in', userName, password, user, 'amongst', _.keys( wrapper.users ) );


### PR DESCRIPTION
Found an issue where closed sockets were being kept around in memory, because they did not get removed from a lookup hash in `socket.js`.

- The lookup was happening always with `socket.id`
- When a connection was added, the key being used when not anonymous was `socket.user`, which is an object. So, the key was a toString of the object. I changed this to use try to use the user's id, then name. If there is no user on a lookup, then it would use the `socket.id`.
- Also, when fixing tests, found two cases where `_.where` is used with a function, rather than `_.filter`. Apparently, `_.where` (at least now) expects an object rather than a function and when given a function returns the entire array. So, the results were not being filtered.
- There are more tests, I believe, that could be written around this part of the functionality. I would be willing to write additional tests, if it would be prudent either for this PR or as a follow-up at some point.